### PR TITLE
server: decode_invoice, get_invoice, and pay_offer endpoints

### DIFF
--- a/docs/cli_commands.md
+++ b/docs/cli_commands.md
@@ -18,9 +18,10 @@ A cli for interacting with lndk
 Usage: lndk-cli [OPTIONS] <COMMAND>
 
 Commands:
-  decode     Decodes a bech32-encoded offer string into a BOLT 12 offer
-  pay-offer  PayOffer pays a BOLT 12 offer, provided as a 'lno'-prefaced offer string
-  help       Print this message or the help of the given subcommand(s)
+  decode-offer    Decodes a bech32-encoded offer string into a BOLT 12 offer
+  decode-invoice  Decodes a bech32-encoded invoice string into a BOLT 12 invoice
+  pay-offer       PayOffer pays a BOLT 12 offer, provided as a 'lno'-prefaced offer string
+  help            Print this message or the help of the given subcommand(s)
 
 Options:
   -n, --network <NETWORK>              Global variables [default: regtest]          

--- a/proto/lndkrpc.proto
+++ b/proto/lndkrpc.proto
@@ -3,6 +3,8 @@ package lndkrpc;
 
 service Offers {
     rpc PayOffer (PayOfferRequest) returns (PayOfferResponse);
+    rpc GetInvoice (GetInvoiceRequest) returns (GetInvoiceResponse);
+    rpc PayInvoice (PayInvoiceRequest) returns (PayInvoiceResponse);
 }
 
 message PayOfferRequest {
@@ -12,4 +14,22 @@ message PayOfferRequest {
 
 message PayOfferResponse {
     string payment_preimage = 2;
+}
+
+message GetInvoiceRequest {
+    string offer = 1;
+    optional uint64 amount = 2;
+}
+
+message GetInvoiceResponse {
+    string invoice = 1;
+}
+
+message PayInvoiceRequest {
+    string invoice = 1;
+    optional uint64 amount = 2;
+}
+
+message PayInvoiceResponse {
+    string payment_preimage = 1;
 }

--- a/proto/lndkrpc.proto
+++ b/proto/lndkrpc.proto
@@ -4,6 +4,7 @@ package lndkrpc;
 service Offers {
     rpc PayOffer (PayOfferRequest) returns (PayOfferResponse);
     rpc GetInvoice (GetInvoiceRequest) returns (GetInvoiceResponse);
+    rpc DecodeInvoice (DecodeInvoiceRequest) returns (Bolt12InvoiceContents);
     rpc PayInvoice (PayInvoiceRequest) returns (PayInvoiceResponse);
 }
 
@@ -19,6 +20,10 @@ message PayOfferResponse {
 message GetInvoiceRequest {
     string offer = 1;
     optional uint64 amount = 2;
+}
+
+message DecodeInvoiceRequest {
+    string invoice = 1;
 }
 
 message GetInvoiceResponse {

--- a/proto/lndkrpc.proto
+++ b/proto/lndkrpc.proto
@@ -22,7 +22,8 @@ message GetInvoiceRequest {
 }
 
 message GetInvoiceResponse {
-    Bolt12Invoice invoice = 1;
+    string invoice = 1;
+    Bolt12Invoice contents = 2;
 }
 
 message PayInvoiceRequest {

--- a/proto/lndkrpc.proto
+++ b/proto/lndkrpc.proto
@@ -23,7 +23,7 @@ message GetInvoiceRequest {
 
 message GetInvoiceResponse {
     string invoice = 1;
-    Bolt12Invoice contents = 2;
+    Bolt12InvoiceContents contents = 2;
 }
 
 message PayInvoiceRequest {
@@ -42,7 +42,7 @@ message Bolt12InvoiceRequest {
     repeated FeatureBit features = 4;
 }
 
-message Bolt12Invoice {
+message Bolt12InvoiceContents {
     Bolt12InvoiceRequest request = 1;
     uint64 amount_msats = 2;
     string description = 3;

--- a/proto/lndkrpc.proto
+++ b/proto/lndkrpc.proto
@@ -22,7 +22,7 @@ message GetInvoiceRequest {
 }
 
 message GetInvoiceResponse {
-    string invoice = 1;
+    Bolt12Invoice invoice = 1;
 }
 
 message PayInvoiceRequest {
@@ -32,4 +32,87 @@ message PayInvoiceRequest {
 
 message PayInvoiceResponse {
     string payment_preimage = 1;
+}
+
+message Bolt12InvoiceRequest {
+    uint64 amount_msats = 1;
+    string chain = 2;
+    optional uint64 quantity = 3;
+    repeated FeatureBit features = 4;
+}
+
+message Bolt12Invoice {
+    Bolt12InvoiceRequest request = 1;
+    uint64 amount_msats = 2;
+    string description = 3;
+    PaymentHash payment_hash = 4;
+    repeated PaymentPaths payment_paths = 5;
+    int64 created_at = 6;
+    uint64 relative_expiry = 7;
+    PublicKey node_id = 8;
+    string signature = 9;
+    repeated FeatureBit features = 10;
+}
+
+message PaymentHash {
+    bytes hash = 1;
+}
+
+message PublicKey {
+    bytes key = 1;
+}
+
+message BlindedPayInfo {
+    uint32 fee_base_msat = 1;
+    uint32 fee_proportional_millionths = 2;
+    uint32 cltv_expiry_delta = 3;
+    uint64 htlc_minimum_msat = 4;
+    uint64 htlc_maximum_msat = 5;
+    repeated FeatureBit features = 6;
+}
+
+message BlindedHop {
+    PublicKey blinded_node_id = 1;
+    bytes encrypted_payload = 2;
+}
+
+message BlindedPath {
+    PublicKey introduction_node_id = 1;
+    PublicKey blinding_point = 2;
+    repeated BlindedHop blinded_hops = 3;
+}
+
+message PaymentPaths {
+    BlindedPayInfo blinded_pay_info = 2;
+    BlindedPath blinded_path = 3;
+}
+
+enum FeatureBit {
+    DATALOSS_PROTECT_REQ = 0;
+    DATALOSS_PROTECT_OPT = 1;
+    INITIAL_ROUING_SYNC = 3;
+    UPFRONT_SHUTDOWN_SCRIPT_REQ = 4;
+    UPFRONT_SHUTDOWN_SCRIPT_OPT = 5;
+    GOSSIP_QUERIES_REQ = 6;
+    GOSSIP_QUERIES_OPT = 7;
+    TLV_ONION_REQ = 8;
+    TLV_ONION_OPT = 9;
+    EXT_GOSSIP_QUERIES_REQ = 10;
+    EXT_GOSSIP_QUERIES_OPT = 11;
+    STATIC_REMOTE_KEY_REQ = 12;
+    STATIC_REMOTE_KEY_OPT = 13;
+    PAYMENT_ADDR_REQ = 14;
+    PAYMENT_ADDR_OPT = 15;
+    MPP_REQ = 16;
+    MPP_OPT = 17;
+    WUMBO_CHANNELS_REQ = 18;
+    WUMBO_CHANNELS_OPT = 19;
+    ANCHORS_REQ = 20;
+    ANCHORS_OPT = 21;
+    ANCHORS_ZERO_FEE_HTLC_REQ = 22;
+    ANCHORS_ZERO_FEE_HTLC_OPT = 23;
+    ROUTE_BLINDING_REQUIRED = 24;
+    ROUTE_BLINDING_OPTIONAL = 25;
+    AMP_REQ = 30;
+    AMP_OPT = 31;
 }

--- a/proto/lndkrpc.proto
+++ b/proto/lndkrpc.proto
@@ -35,24 +35,18 @@ message PayInvoiceResponse {
     string payment_preimage = 1;
 }
 
-message Bolt12InvoiceRequest {
-    uint64 amount_msats = 1;
-    string chain = 2;
-    optional uint64 quantity = 3;
-    repeated FeatureBit features = 4;
-}
-
 message Bolt12InvoiceContents {
-    Bolt12InvoiceRequest request = 1;
-    uint64 amount_msats = 2;
-    string description = 3;
-    PaymentHash payment_hash = 4;
-    repeated PaymentPaths payment_paths = 5;
-    int64 created_at = 6;
-    uint64 relative_expiry = 7;
-    PublicKey node_id = 8;
-    string signature = 9;
-    repeated FeatureBit features = 10;
+    string chain = 1;
+    optional uint64 quantity = 2;
+    uint64 amount_msats = 3;
+    string description = 4;
+    PaymentHash payment_hash = 5;
+    repeated PaymentPaths payment_paths = 6;
+    int64 created_at = 7;
+    uint64 relative_expiry = 8;
+    PublicKey node_id = 9;
+    string signature = 10;
+    repeated FeatureBit features = 11;
 }
 
 message PaymentHash {

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -122,9 +122,7 @@ async fn main() {
         }
         Commands::DecodeInvoice { invoice_string } => {
             println!("Decoding invoice: {invoice_string}.");
-
             let invoice_string: Bolt12InvoiceString = invoice_string.clone().into();
-
             match Bolt12Invoice::try_from(invoice_string) {
                 Ok(invoice) => {
                     println!("Decoded invoice: {:?}.", invoice);

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,8 +1,9 @@
 use clap::{Parser, Subcommand};
+use lightning::offers::invoice::Bolt12Invoice;
 use lndk::lndk_offers::decode;
 use lndk::lndkrpc::offers_client::OffersClient;
 use lndk::lndkrpc::{GetInvoiceRequest, PayInvoiceRequest, PayOfferRequest};
-use lndk::{DEFAULT_DATA_DIR, DEFAULT_SERVER_HOST, DEFAULT_SERVER_PORT, TLS_CERT_FILENAME};
+use lndk::{Bolt12InvoiceString, DEFAULT_DATA_DIR, DEFAULT_SERVER_HOST, DEFAULT_SERVER_PORT, TLS_CERT_FILENAME};
 use std::fs::File;
 use std::io::BufReader;
 use std::io::Read;
@@ -59,9 +60,14 @@ struct Cli {
 #[derive(Debug, Subcommand)]
 enum Commands {
     /// Decodes a bech32-encoded offer string into a BOLT 12 offer.
-    Decode {
+    DecodeOffer {
         /// The offer string to decode.
         offer_string: String,
+    },
+    /// Decodes a bech32-encoded invoice string into a BOLT 12 invoice.
+    DecodeInvoice {
+        /// The invoice string to decode.
+        invoice_string: String,
     },
     /// PayOffer pays a BOLT 12 offer, provided as a 'lno'-prefaced offer string.
     PayOffer {
@@ -98,7 +104,7 @@ enum Commands {
 async fn main() {
     let args = Cli::parse();
     match args.command {
-        Commands::Decode { offer_string } => {
+        Commands::DecodeOffer { offer_string } => {
             println!("Decoding offer: {offer_string}.");
             match decode(offer_string) {
                 Ok(offer) => {
@@ -111,6 +117,25 @@ async fn main() {
                         e
                     );
                     exit(1)
+                }
+            }
+        }
+        Commands::DecodeInvoice { invoice_string } => {
+            println!("Decoding invoice: {invoice_string}.");
+
+            let invoice_string: Bolt12InvoiceString = invoice_string.clone().into();
+
+            match Bolt12Invoice::try_from(invoice_string) {
+                Ok(invoice) => {
+                    println!("Decoded invoice: {:?}.", invoice);
+                }
+                Err(e) => {
+                    println!(
+                        "ERROR please provide hex encoded invoice starting. Provided invoice is \
+                        invalid, failed to decode with error: {:?}.",
+                        e
+                    );
+                    exit(1);
                 }
             }
         }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,7 +1,7 @@
 use clap::{Parser, Subcommand};
 use lndk::lndk_offers::decode;
 use lndk::lndkrpc::offers_client::OffersClient;
-use lndk::lndkrpc::PayOfferRequest;
+use lndk::lndkrpc::{GetInvoiceRequest, PayInvoiceRequest, PayOfferRequest};
 use lndk::{DEFAULT_DATA_DIR, DEFAULT_SERVER_HOST, DEFAULT_SERVER_PORT, TLS_CERT_FILENAME};
 use std::fs::File;
 use std::io::BufReader;
@@ -73,6 +73,25 @@ enum Commands {
         #[arg(required = false)]
         amount: Option<u64>,
     },
+    /// GetInvoice fetch an invoice, will be returned as a hex-encoded string. It fetches the
+    /// invoice from a BOLT 12 offer, provided as a 'lno'-prefaced offer string.
+    GetInvoice {
+        /// The offer string.
+        offer_string: String,
+        /// Amount the user would like to pay. If this isn't set, we'll assume the user is paying
+        /// whatever the offer amount is.
+        #[arg(required = false)]
+        amount: Option<u64>,
+    },
+    /// PayInvoice pays a BOLT12 hex-encoded TLV invoice.
+    PayInvoice {
+        /// The encoded invoice string.
+        invoice_string: String,
+        /// Amount the user would like to pay. If this isn't set, we'll assume the user is paying
+        /// whatever the invoice amount is set to.
+        #[arg(required = false)]
+        amount: Option<u64>,
+    },
 }
 
 #[tokio::main]
@@ -102,7 +121,7 @@ async fn main() {
             let tls = read_cert_from_args(&args);
             let grpc_host = args.grpc_host.clone();
             let grpc_port = args.grpc_port;
-            let channel = Channel::from_shared(format!("{grpc_host}:{grpc_port}")) //
+            let channel = Channel::from_shared(format!("{grpc_host}:{grpc_port}"))
                 .unwrap_or_else(|e| {
                     println!("ERROR creating endpoint: {e:?}");
                     exit(1)
@@ -148,10 +167,102 @@ async fn main() {
                 }
             };
         }
+        Commands::GetInvoice {
+            ref offer_string,
+            amount,
+        } => {
+            let tls = read_cert_from_args(&args);
+            let grpc_host = args.grpc_host.clone();
+            let grpc_port = args.grpc_port;
+            let channel = Channel::from_shared(format!("{grpc_host}:{grpc_port}"))
+                .unwrap_or_else(|e| {
+                    println!("ERROR creating endpoint: {e:?}");
+                    exit(1)
+                })
+                .tls_config(tls)
+                .unwrap_or_else(|e| {
+                    println!("ERROR tls config: {e:?}");
+                    exit(1)
+                })
+                .connect()
+                .await
+                .unwrap_or_else(|e| {
+                    println!("ERROR connecting: {e:?}");
+                    exit(1)
+                });
+
+            let mut client = OffersClient::new(channel);
+            let offer = match decode(offer_string.to_owned()) {
+                Ok(offer) => offer,
+                Err(e) => {
+                    println!(
+                        "ERROR: please provide offer starting with lno. Provided offer is \
+                        invalid, failed to decode with error: {:?}.",
+                        e
+                    );
+                    exit(1)
+                }
+            };
+
+            let macaroon = read_macaroon_from_args(&args);
+            let mut request = Request::new(GetInvoiceRequest {
+                offer: offer.to_string(),
+                amount,
+            });
+            add_metadata(&mut request, macaroon).unwrap_or_else(|_| exit(1));
+            match client.get_invoice(request).await {
+                Ok(response) => {
+                    println!("Invoice: {:?}.", response.get_ref().invoice)
+                }
+                Err(err) => {
+                    println!("Error getting invoice for offer: {err:?}");
+                    exit(1)
+                }
+            }
+        }
+        Commands::PayInvoice {
+            ref invoice_string,
+            amount,
+        } => {
+            let tls = read_cert_from_args(&args);
+            let grpc_host = args.grpc_host.clone();
+            let grpc_port = args.grpc_port;
+            let channel = Channel::from_shared(format!("{grpc_host}:{grpc_port}"))
+                .unwrap_or_else(|e| {
+                    println!("ERROR creating endpoint: {e:?}");
+                    exit(1)
+                })
+                .tls_config(tls)
+                .unwrap_or_else(|e| {
+                    println!("ERROR tls config: {e:?}");
+                    exit(1)
+                })
+                .connect()
+                .await
+                .unwrap_or_else(|e| {
+                    println!("ERROR connecting: {e:?}");
+                    exit(1)
+                });
+
+            let mut client = OffersClient::new(channel);
+            let macaroon = read_macaroon_from_args(&args);
+            let mut request = Request::new(PayInvoiceRequest {
+                invoice: invoice_string.to_owned(),
+                amount,
+            });
+            add_metadata(&mut request, macaroon).unwrap_or_else(|_| exit(1));
+            match client.pay_invoice(request).await {
+                Ok(_) => println!("Successfully paid for offer!"),
+                Err(err) => {
+                    println!("Error paying invoice: {err:?}");
+                    exit(1)
+                }
+            }
+        }
     }
 }
 
-fn add_metadata(request: &mut Request<PayOfferRequest>, macaroon: String) -> Result<(), ()> {
+fn add_metadata<R>(request: &mut Request<R>, macaroon: String) -> Result<(), ()> {
     let macaroon = macaroon.parse().map_err(|e| {
         println!("Error parsing provided macaroon string into tonic metadata {e:?}")
     })?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,6 +21,7 @@ use home::home_dir;
 use lightning::blinded_path::BlindedPath;
 use lightning::ln::channelmanager::PaymentId;
 use lightning::ln::inbound_payment::ExpandedKey;
+use lightning::ln::msgs::DecodeError;
 use lightning::ln::peer_handler::IgnoringMessageHandler;
 use lightning::offers::invoice::Bolt12Invoice;
 use lightning::offers::invoice_error::InvoiceError;
@@ -435,6 +436,23 @@ impl OffersMessageHandler for OfferHandler {
 
     fn release_pending_messages(&self) -> Vec<PendingOnionMessage<OffersMessage>> {
         core::mem::take(&mut self.pending_messages.lock().unwrap())
+    }
+}
+
+pub struct Bolt12InvoiceString(pub String);
+
+impl TryFrom<Bolt12InvoiceString> for Bolt12Invoice {
+    type Error = DecodeError;
+
+    fn try_from(s: Bolt12InvoiceString) -> Result<Self, Self::Error> {
+        let bytes: Vec<u8> = hex::decode(s.0).unwrap();
+        Self::try_from(bytes).map_err(|_| DecodeError::InvalidValue)
+    }
+}
+
+impl From<String> for Bolt12InvoiceString {
+    fn from(s: String) -> Self {
+        Bolt12InvoiceString(s)
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -272,6 +272,19 @@ impl OfferHandler {
         cfg: PayOfferParams,
     ) -> Result<Payment, OfferError<Secp256k1Error>> {
         let client_clone = cfg.client.clone();
+        let (invoice, validated_amount, payment_id) = self.get_invoice(cfg).await?;
+
+        self.pay_invoice(client_clone, validated_amount, &invoice, payment_id)
+            .await
+    }
+
+    // Sends an invoice request and waits for an invoice to be sent back to us.
+    // Reminder that if this method returns an error after create_invoice_request is called, we
+    // *must* remove the payment_id from self.active_payments.
+    pub async fn get_invoice(
+        &self,
+        cfg: PayOfferParams,
+    ) -> Result<(Bolt12Invoice, u64, PaymentId), OfferError<Secp256k1Error>> {
         let (invoice_request, payment_id, validated_amount) = self
             .create_invoice_request(
                 cfg.client.clone(),
@@ -312,6 +325,19 @@ impl OfferHandler {
                 .and_modify(|entry| entry.state = PaymentState::InvoiceReceived);
         }
 
+        Ok((invoice, validated_amount, payment_id))
+    }
+
+    // Sends an invoice request and waits for an invoice to be sent back to us.
+    // Reminder that if this method returns an error after create_invoice_request is called, we
+    // *must* remove the payment_id from self.active_payments.
+    pub async fn pay_invoice(
+        &self,
+        client: Client,
+        amount: u64,
+        invoice: &Bolt12Invoice,
+        payment_id: PaymentId,
+    ) -> Result<Payment, OfferError<Secp256k1Error>> {
         let payment_hash = invoice.payment_hash();
         let path_info = invoice.payment_paths()[0].clone();
 
@@ -321,11 +347,11 @@ impl OfferHandler {
             fee_base_msat: path_info.0.fee_base_msat,
             fee_ppm: path_info.0.fee_proportional_millionths,
             payment_hash: payment_hash.0,
-            msats: validated_amount,
+            msats: amount,
             payment_id,
         };
 
-        self.send_payment(client_clone, params)
+        self.send_payment(client, params)
             .await
             .map(|payment| {
                 let mut active_payments = self.active_payments.lock().unwrap();

--- a/src/lndk_offers.rs
+++ b/src/lndk_offers.rs
@@ -268,11 +268,11 @@ impl OfferHandler {
         }
     }
 
-    /// pay_invoice tries to pay the provided invoice.
-    pub(crate) async fn pay_invoice(
+    /// send_payment tries to pay the provided invoice using LND.
+    pub(crate) async fn send_payment(
         &self,
         mut payer: impl InvoicePayer + std::marker::Send + 'static,
-        params: PayInvoiceParams,
+        params: SendPaymentParams,
     ) -> Result<Payment, OfferError<Secp256k1Error>> {
         debug!(
             "Attempting to pay invoice with introduction node {}",
@@ -310,14 +310,13 @@ impl OfferHandler {
     }
 }
 
-pub struct PayInvoiceParams {
+pub struct SendPaymentParams {
     pub path: BlindedPath,
     pub cltv_expiry_delta: u16,
     pub fee_base_msat: u32,
     pub fee_ppm: u32,
     pub payment_hash: [u8; 32],
     pub msats: u64,
-    pub offer_id: String,
     pub payment_id: PaymentId,
 }
 
@@ -946,7 +945,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_pay_invoice() {
+    async fn test_send_payment() {
         let mut payer_mock = MockTestInvoicePayer::new();
 
         payer_mock.expect_query_routes().returning(|_, _, _, _, _| {
@@ -975,21 +974,20 @@ mod tests {
         let payment_hash = MessengerUtilities::new().get_secure_random_bytes();
         let handler = OfferHandler::new();
         let payment_id = PaymentId(MessengerUtilities::new().get_secure_random_bytes());
-        let params = PayInvoiceParams {
+        let params = SendPaymentParams {
             path: blinded_path,
             cltv_expiry_delta: 200,
             fee_base_msat: 1,
             fee_ppm: 0,
             payment_hash: payment_hash,
             msats: 2000,
-            offer_id: get_offer(),
             payment_id,
         };
-        assert!(handler.pay_invoice(payer_mock, params).await.is_ok());
+        assert!(handler.send_payment(payer_mock, params).await.is_ok());
     }
 
     #[tokio::test]
-    async fn test_pay_invoice_query_error() {
+    async fn test_send_payment_query_error() {
         let mut payer_mock = MockTestInvoicePayer::new();
 
         payer_mock
@@ -1000,21 +998,20 @@ mod tests {
         let payment_hash = MessengerUtilities::new().get_secure_random_bytes();
         let payment_id = PaymentId(MessengerUtilities::new().get_secure_random_bytes());
         let handler = OfferHandler::new();
-        let params = PayInvoiceParams {
+        let params = SendPaymentParams {
             path: blinded_path,
             cltv_expiry_delta: 200,
             fee_base_msat: 1,
             fee_ppm: 0,
             payment_hash: payment_hash,
             msats: 2000,
-            offer_id: get_offer(),
             payment_id,
         };
-        assert!(handler.pay_invoice(payer_mock, params).await.is_err());
+        assert!(handler.send_payment(payer_mock, params).await.is_err());
     }
 
     #[tokio::test]
-    async fn test_pay_invoice_send_error() {
+    async fn test_send_payment_send_error() {
         let mut payer_mock = MockTestInvoicePayer::new();
 
         payer_mock.expect_query_routes().returning(|_, _, _, _, _| {
@@ -1035,16 +1032,15 @@ mod tests {
         let payment_hash = MessengerUtilities::new().get_secure_random_bytes();
         let payment_id = PaymentId(MessengerUtilities::new().get_secure_random_bytes());
         let handler = OfferHandler::new();
-        let params = PayInvoiceParams {
+        let params = SendPaymentParams {
             path: blinded_path,
             cltv_expiry_delta: 200,
             fee_base_msat: 1,
             fee_ppm: 0,
             payment_hash: payment_hash,
             msats: 2000,
-            offer_id: get_offer(),
             payment_id,
         };
-        assert!(handler.pay_invoice(payer_mock, params).await.is_err());
+        assert!(handler.send_payment(payer_mock, params).await.is_err());
     }
 }

--- a/src/lndk_offers.rs
+++ b/src/lndk_offers.rs
@@ -160,7 +160,7 @@ impl OfferHandler {
         network: Network,
         msats: Option<u64>,
     ) -> Result<(InvoiceRequest, PaymentId, u64), OfferError<bitcoin::secp256k1::Error>> {
-        let validated_amount = validate_amount(&offer, msats).await?;
+        let validated_amount = validate_amount(offer.amount(), msats).await?;
 
         // We use KeyFamily KeyFamilyNodeKey (6) to derive a key to represent our node id. See:
         // https://github.com/lightningnetwork/lnd/blob/a3f8011ed695f6204ec6a13ad5c2a67ac542b109/keychain/derivation.go#L103
@@ -320,12 +320,12 @@ pub struct SendPaymentParams {
     pub payment_id: PaymentId,
 }
 
-// Checks that the user-provided amount matches the offer.
+// Checks that the user-provided amount matches the provided offer or invoice.
 pub async fn validate_amount(
-    offer: &Offer,
-    amount_msats: Option<u64>,
+    offer_amount: Option<&Amount>, // The amount set in the offer or invoice.
+    amount_msats: Option<u64>,     // The amount we want to pay.
 ) -> Result<u64, OfferError<bitcoin::secp256k1::Error>> {
-    let validated_amount = match offer.amount() {
+    let validated_amount = match offer_amount {
         Some(offer_amount) => {
             match *offer_amount {
                 Amount::Bitcoin {
@@ -775,21 +775,21 @@ mod tests {
         // If the amount the user provided is greater than the offer-provided amount, then
         // we should be good.
         let offer = build_custom_offer(20000);
-        assert!(validate_amount(&offer, Some(20000)).await.is_ok());
+        assert!(validate_amount(offer.amount(), Some(20000)).await.is_ok());
 
         let offer = build_custom_offer(0);
-        assert!(validate_amount(&offer, Some(20000)).await.is_ok());
+        assert!(validate_amount(offer.amount(), Some(20000)).await.is_ok());
     }
 
     #[tokio::test]
     async fn test_validate_invalid_amount() {
         // If the amount the user provided is lower than the offer amount, we error.
         let offer = build_custom_offer(20000);
-        assert!(validate_amount(&offer, Some(1000)).await.is_err());
+        assert!(validate_amount(offer.amount(), Some(1000)).await.is_err());
 
         // Both user amount and offer amount can't be 0.
         let offer = build_custom_offer(0);
-        assert!(validate_amount(&offer, None).await.is_err());
+        assert!(validate_amount(offer.amount(), None).await.is_err());
     }
 
     #[tokio::test]

--- a/src/lndk_offers.rs
+++ b/src/lndk_offers.rs
@@ -94,7 +94,7 @@ impl Display for OfferError<Secp256k1Error> {
 
 impl Error for OfferError<Secp256k1Error> {}
 
-// Decodes a bech32 string into an LDK offer.
+// Decodes a bech32 offer string into an LDK offer.
 pub fn decode(offer_str: String) -> Result<Offer, Bolt12ParseError> {
     offer_str.parse::<Offer>()
 }

--- a/src/onion_messenger.rs
+++ b/src/onion_messenger.rs
@@ -27,7 +27,8 @@ use std::io::Cursor;
 use std::marker::Copy;
 use std::str::FromStr;
 use tokio::sync::mpsc::{channel, Receiver, Sender};
-use tokio::{select, time, time::Duration, time::Interval};
+use tokio::time::{sleep, timeout, Duration};
+use tokio::{select, time, time::Interval};
 use tonic_lnd::{
     lnrpc::peer_event::EventType::PeerOffline, lnrpc::peer_event::EventType::PeerOnline,
     lnrpc::CustomMessage, lnrpc::PeerEvent, lnrpc::SendCustomMessageRequest,
@@ -282,7 +283,26 @@ async fn lookup_onion_support(pubkey: &PublicKey, client: &mut tonic_lnd::Lightn
                     continue;
                 }
 
-                return features_support_onion_messages(&peer.features);
+                // Sometimes if the connection to the peer is very new, we have to wait for the
+                // features map to populate as non-empty.
+                let check_empty_timeout = 5;
+                let features = match timeout(
+                    Duration::from_secs(check_empty_timeout),
+                    check_empty_features(pubkey, client.clone()),
+                )
+                .await
+                {
+                    Ok(features) => features,
+                    Err(_) => {
+                        warn!(
+                            "Did not get non-empty feature set from peer {} set in {} seconds.",
+                            peer.pub_key, check_empty_timeout
+                        );
+                        peer.features
+                    }
+                };
+
+                return features_support_onion_messages(&features);
             }
 
             warn!("Peer {pubkey} not found in current set of peers, assuming no onion support.");
@@ -292,6 +312,39 @@ async fn lookup_onion_support(pubkey: &PublicKey, client: &mut tonic_lnd::Lightn
             warn!("Could not lookup peers for {pubkey}: {e}, assuming no onion message support.");
             false
         }
+    }
+}
+
+// check_empty_features repeatedly looks up the peer's feature set until it returns a non-empty
+// map. Sometimes if a peer is new, LND needs a little time to update the feature set.
+async fn check_empty_features(
+    pubkey: &PublicKey,
+    mut client: LightningClient,
+) -> HashMap<u32, tonic_lnd::lnrpc::Feature> {
+    loop {
+        match client
+            .list_peers(tonic_lnd::lnrpc::ListPeersRequest {
+                latest_error: false,
+            })
+            .await
+        {
+            Ok(peers) => {
+                for peer in peers.into_inner().peers {
+                    if peer.pub_key != pubkey.to_string() {
+                        continue;
+                    }
+
+                    if !peer.features.is_empty() {
+                        return peer.features;
+                    }
+                }
+            }
+            Err(_) => {
+                warn!("error connecting to listpeers");
+                continue;
+            }
+        };
+        sleep(Duration::from_millis(500)).await;
     }
 }
 

--- a/src/rate_limit.rs
+++ b/src/rate_limit.rs
@@ -20,6 +20,10 @@ impl PeerRecord {
             remaining_calls,
         }
     }
+
+    pub(crate) fn onion_support(&self) -> bool {
+        self.onion_support
+    }
 }
 
 /// RateLimiter provides peer tracking and rate limiting for lightning peers.

--- a/src/server.rs
+++ b/src/server.rs
@@ -59,7 +59,7 @@ impl Offers for LNDKServer {
         &self,
         request: Request<PayOfferRequest>,
     ) -> Result<Response<PayOfferResponse>, Status> {
-        log::info!("Received a request: {:?}", request);
+        log::info!("Received a request: {:?}", request.get_ref());
 
         let metadata = request.metadata();
         let macaroon = check_auth_metadata(metadata)?;

--- a/src/server.rs
+++ b/src/server.rs
@@ -13,7 +13,7 @@ use lightning::sign::EntropySource;
 use lightning::util::ser::Writeable;
 use lndkrpc::offers_server::Offers;
 use lndkrpc::{
-    Bolt12InvoiceContents, Bolt12InvoiceRequest, GetInvoiceRequest, GetInvoiceResponse,
+    Bolt12InvoiceContents, GetInvoiceRequest, GetInvoiceResponse, DecodeInvoiceRequest,
     PayInvoiceRequest, PayInvoiceResponse, PayOfferRequest, PayOfferResponse,
     PaymentHash, PaymentPaths, FeatureBit
 };
@@ -209,7 +209,7 @@ impl Offers for LNDKServer {
 
         let reply: GetInvoiceResponse = GetInvoiceResponse {
             invoice: encode_invoice_as_hex(&invoice)?,
-            contents: Some(generate_bolt12_invoice_contents(&invoice, &inner_request)),
+            contents: Some(generate_bolt12_invoice_contents(&invoice)),
         };
 
         Ok(Response::new(reply))
@@ -274,14 +274,10 @@ impl Offers for LNDKServer {
     }
 }
 
-fn generate_bolt12_invoice_contents(invoice: &Bolt12Invoice, invoice_request: &GetInvoiceRequest) -> lndkrpc::Bolt12InvoiceContents {
+fn generate_bolt12_invoice_contents(invoice: &Bolt12Invoice) -> lndkrpc::Bolt12InvoiceContents {
     Bolt12InvoiceContents {
-        request: Some(Bolt12InvoiceRequest {
-            amount_msats: invoice_request.amount(),
-            chain: invoice.chain().to_string(),
-            quantity: invoice.quantity(),
-            features: convert_features(invoice.invoice_features().clone().encode()),
-        }),
+        chain: invoice.chain().to_string(),
+        quantity: invoice.quantity(),
         amount_msats: invoice.amount_msats(),
         description: invoice.description().to_string(),
         payment_hash: Some(PaymentHash {

--- a/src/server.rs
+++ b/src/server.rs
@@ -292,8 +292,16 @@ impl Offers for LNDKServer {
             hash: invoice.payment_hash().encode(),
         };
 
+        let mut buffer = Vec::new();
+        {
+            invoice
+                .write(&mut buffer)
+                .map_err(|e| Status::internal(format!("Error serializing invoice: {e}")))?
+        }
+
         let reply = GetInvoiceResponse {
-            invoice: Some(lndkrpc::Bolt12Invoice {
+            invoice: hex::encode(buffer),
+            contents: Some(lndkrpc::Bolt12Invoice {
                 request: Some(Bolt12InvoiceRequest {
                     amount_msats: inner_request.amount(),
                     chain: invoice.chain().to_string(),

--- a/src/server.rs
+++ b/src/server.rs
@@ -1,12 +1,20 @@
 use crate::lnd::{get_lnd_client, get_network, Creds, LndCfg};
-use crate::lndk_offers::get_destination;
+use crate::lndk_offers::{get_destination, validate_amount};
 use crate::{
-    lndkrpc, OfferError, OfferHandler, PayOfferParams, TLS_CERT_FILENAME, TLS_KEY_FILENAME,
+    lndkrpc, Bolt12InvoiceString, OfferError, OfferHandler, PayOfferParams, TLS_CERT_FILENAME,
+    TLS_KEY_FILENAME,
 };
 use bitcoin::secp256k1::PublicKey;
+use lightning::ln::channelmanager::PaymentId;
+use lightning::offers::invoice::Bolt12Invoice;
 use lightning::offers::offer::Offer;
+use lightning::sign::EntropySource;
+use lightning::util::ser::Writeable;
 use lndkrpc::offers_server::Offers;
-use lndkrpc::{PayOfferRequest, PayOfferResponse};
+use lndkrpc::{
+    GetInvoiceRequest, GetInvoiceResponse, PayInvoiceRequest, PayInvoiceResponse, PayOfferRequest,
+    PayOfferResponse,
+};
 use rcgen::{generate_simple_self_signed, CertifiedKey, Error as RcgenError};
 use std::error::Error;
 use std::fmt::Display;
@@ -117,6 +125,153 @@ impl Offers for LNDKServer {
 
         let reply = PayOfferResponse {
             payment_preimage: payment.payment_preimage,
+        };
+
+        Ok(Response::new(reply))
+    }
+
+    async fn get_invoice(
+        &self,
+        request: Request<GetInvoiceRequest>,
+    ) -> Result<Response<GetInvoiceResponse>, Status> {
+        log::info!("Received a request: {:?}", request);
+
+        let metadata = request.metadata();
+        let macaroon = check_auth_metadata(metadata)?;
+        let creds = Creds::String {
+            cert: self.lnd_cert.clone(),
+            macaroon,
+        };
+        let lnd_cfg = LndCfg::new(self.address.clone(), creds);
+        let mut client = get_lnd_client(lnd_cfg)
+            .map_err(|e| Status::unavailable(format!("Couldn't connect to lnd: {e}")))?;
+
+        let inner_request = request.get_ref();
+        let offer = Offer::from_str(&inner_request.offer).map_err(|e| {
+            Status::invalid_argument(format!(
+                "The provided offer was invalid. Please provide a valid offer in bech32 format,
+                i.e. starting with 'lno'. Error: {e:?}"
+            ))
+        })?;
+
+        let destination = get_destination(&offer).await;
+        let reply_path = match self
+            .offer_handler
+            .create_reply_path(client.clone(), self.node_id)
+            .await
+        {
+            Ok(reply_path) => reply_path,
+            Err(e) => return Err(Status::internal(format!("Internal error: {e}"))),
+        };
+
+        let info = client
+            .lightning()
+            .get_info(GetInfoRequest {})
+            .await
+            .expect("failed to get info")
+            .into_inner();
+        let network = get_network(info)
+            .await
+            .map_err(|e| Status::internal(format!("{e:?}")))?;
+
+        let cfg = PayOfferParams {
+            offer,
+            amount: inner_request.amount,
+            network,
+            client,
+            destination,
+            reply_path: Some(reply_path),
+        };
+
+        let (invoice, _, payment_id) = match self.offer_handler.get_invoice(cfg).await {
+            Ok(invoice) => {
+                log::info!("Invoice request succeeded.");
+                invoice
+            }
+            Err(e) => match e {
+                OfferError::InvalidAmount(e) => {
+                    return Err(Status::invalid_argument(e.to_string()))
+                }
+                OfferError::InvalidCurrency => {
+                    return Err(Status::invalid_argument(format!("{e}")))
+                }
+                _ => return Err(Status::internal(format!("Internal error: {e}"))),
+            },
+        };
+
+        // We need to remove the payment from our tracking map now.
+        {
+            let mut active_payments = self.offer_handler.active_payments.lock().unwrap();
+            active_payments.remove(&payment_id);
+        }
+
+        let mut buffer = Vec::new();
+        {
+            invoice
+                .write(&mut buffer)
+                .map_err(|e| Status::internal(format!("Error serializing invoice: {e}")))?
+        }
+
+        let reply = GetInvoiceResponse {
+            invoice: hex::encode(buffer),
+        };
+
+        Ok(Response::new(reply))
+    }
+
+    async fn pay_invoice(
+        &self,
+        request: Request<PayInvoiceRequest>,
+    ) -> Result<Response<PayInvoiceResponse>, Status> {
+        log::info!("Received a request: {:?}", request);
+
+        let metadata = request.metadata();
+        let macaroon = check_auth_metadata(metadata)?;
+        let creds = Creds::String {
+            cert: self.lnd_cert.clone(),
+            macaroon,
+        };
+        let lnd_cfg = LndCfg::new(self.address.clone(), creds);
+        let client = get_lnd_client(lnd_cfg)
+            .map_err(|e| Status::unavailable(format!("Couldn't connect to lnd: {e}")))?;
+
+        let inner_request = request.get_ref();
+        let invoice_string: Bolt12InvoiceString = inner_request.invoice.clone().into();
+        let invoice = Bolt12Invoice::try_from(invoice_string).map_err(|e| {
+            Status::invalid_argument(format!(
+                "The provided invoice was invalid. Please provide a valid invoice in hex format.
+                Error: {e:?}"
+            ))
+        })?;
+
+        let amount = match validate_amount(invoice.amount(), inner_request.amount).await {
+            Ok(amount) => amount,
+            Err(e) => return Err(Status::invalid_argument(e.to_string())),
+        };
+        let payment_id = PaymentId(self.offer_handler.messenger_utils.get_secure_random_bytes());
+        let invoice = match self
+            .offer_handler
+            .pay_invoice(client, amount, &invoice, payment_id)
+            .await
+        {
+            Ok(invoice) => {
+                log::info!("Invoice paid.");
+                invoice
+            }
+            // THESE ERRORS AREN'T CORRECT FOR THIS?
+            Err(e) => match e {
+                OfferError::InvalidAmount(e) => {
+                    return Err(Status::invalid_argument(e.to_string()))
+                }
+                OfferError::InvalidCurrency => {
+                    return Err(Status::invalid_argument(format!("{e}")))
+                }
+                _ => return Err(Status::internal(format!("Internal error: {e}"))),
+            },
+        };
+
+        let reply = PayInvoiceResponse {
+            payment_preimage: invoice.payment_preimage,
         };
 
         Ok(Response::new(reply))

--- a/src/server.rs
+++ b/src/server.rs
@@ -132,6 +132,26 @@ impl Offers for LNDKServer {
         Ok(Response::new(reply))
     }
 
+    async fn decode_invoice(
+        &self,
+        request: Request<DecodeInvoiceRequest>,
+    ) -> Result<Response<Bolt12InvoiceContents>, Status> {
+        log::info!("Received a request: {:?}", request);
+        let inner_request: &DecodeInvoiceRequest = request.get_ref();
+        let invoice_string: Bolt12InvoiceString = inner_request.invoice.clone().into();
+        let invoice = match Bolt12Invoice::try_from(invoice_string) {
+            Ok(invoice) => {
+                println!("Decoded invoice: {:?}.", invoice);
+                invoice
+            }
+            Err(e) => {
+                return Err(Status::invalid_argument(e.to_string()))
+            }
+        };
+        let reply: Bolt12InvoiceContents = generate_bolt12_invoice_contents(&invoice);
+        Ok(Response::new(reply))
+    }
+
     async fn get_invoice(
         &self,
         request: Request<GetInvoiceRequest>,

--- a/src/server.rs
+++ b/src/server.rs
@@ -301,7 +301,7 @@ impl Offers for LNDKServer {
 
         let reply = GetInvoiceResponse {
             invoice: hex::encode(buffer),
-            contents: Some(lndkrpc::Bolt12Invoice {
+            contents: Some(lndkrpc::Bolt12InvoiceContents {
                 request: Some(Bolt12InvoiceRequest {
                     amount_msats: inner_request.amount(),
                     chain: invoice.chain().to_string(),


### PR DESCRIPTION
Extends https://github.com/lndk-org/lndk/pull/131 with the following changes:

- Refactors/simplifies the Invoice grpc message types
- Includes the hex encoded invoice in the returned invoice data
- Adds decode-invoice cli and rpc commands
- Little bit of cleanup, extracts helper methods out of endpoint handler