### PR TITLE
server: include payer note in invoice contents

### DIFF
--- a/docs/cli_commands.md
+++ b/docs/cli_commands.md
@@ -62,6 +62,22 @@ which you can do in [most languages](https://grpc.io/docs/languages/).
 Again, since LNDK needs to connect to LND, you'll need to pass in your LND macaroon to establish a connection. Note that:
 - The client must pass in this data via gRPC metadata. You can find an example of this in the [Rust client](https://github.com/lndk-org/lndk/blob/master/src/cli.rs) used to connect `lndk-cli` to the server.
 
+## Baking a custom macaroon
+
+Rather than use the admin.macaroon with unrestricted permission to an LND node, we can bake a macaroon using lncli with much more specific permissions for better security. Note also that the macaroon required for [starting up a LNDK instance](https://github.com/lndk-org/lndk?tab=readme-ov-file#custom-macaroon) requires different permissions than when making a payment.
+
+When using `pay-offer`, you can generate a macaroon which will give LNDK only the specific grpc endpoints it needs to hit:
+
+```
+lncli bakemacaroon --save_to=<FILEPATH>/lndk-pay.macaroon uri:/walletrpc.WalletKit/DeriveKey uri:/signrpc.Signer/SignMessage uri:/lnrpc.Lightning/GetNodeInfo uri:/lnrpc.Lightning/ConnectPeer uri:/lnrpc.Lightning/GetInfo uri:/lnrpc.Lightning/ListPeers uri:/lnrpc.Lightning/GetChanInfo uri:/lnrpc.Lightning/QueryRoutes uri:/routerrpc.Router/SendToRouteV2 uri:/routerrpc.Router/TrackPaymentV2
+```
+
+If you're using just the `get-invoice` command, you can bake a macaroon with less permissions:
+
+```
+lncli bakemacaroon --save_to=<FILEPATH>/lndk-pay.macaroon uri:/walletrpc.WalletKit/DeriveKey uri:/signrpc.Signer/SignMessage uri:/lnrpc.Lightning/GetNodeInfo uri:/lnrpc.Lightning/ConnectPeer uri:/lnrpc.Lightning/GetInfo uri:/lnrpc.Lightning/ListPeers uri:/lnrpc.Lightning/GetChanInfo
+```
+
 ## TLS: Running `lndk-cli` remotely
 
 When `LNDK` is started up, self-signed TLS credentials are automatically generated and stored in `~/.lndk`. If you're running `lndk-cli` locally, it'll know where to find the certificate file it needs to establish a secure connection with the LNDK server.

--- a/proto/lndkrpc.proto
+++ b/proto/lndkrpc.proto
@@ -11,6 +11,7 @@ service Offers {
 message PayOfferRequest {
    string offer = 1;
    optional uint64 amount = 2;
+   optional string payer_note = 3;
 }
 
 message PayOfferResponse {
@@ -20,6 +21,7 @@ message PayOfferResponse {
 message GetInvoiceRequest {
     string offer = 1;
     optional uint64 amount = 2;
+    optional string payer_note = 3;
 }
 
 message DecodeInvoiceRequest {

--- a/proto/lndkrpc.proto
+++ b/proto/lndkrpc.proto
@@ -54,6 +54,7 @@ message Bolt12InvoiceContents {
     PublicKey node_id = 9;
     string signature = 10;
     repeated FeatureBit features = 11;
+    optional string payer_note = 12;
 }
 
 message PaymentHash {

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -81,16 +81,25 @@ enum Commands {
         /// whatever the offer amount is.
         #[arg(required = false)]
         amount: Option<u64>,
+
+        /// A payer-provided note which will be seen by the recipient.
+        #[arg(required = false)]
+        payer_note: Option<String>,
     },
     /// GetInvoice fetch a BOLT 12 invoice, which will be returned as a hex-encoded string. It
     /// fetches the invoice from a BOLT 12 offer, provided as a 'lno'-prefaced offer string.
     GetInvoice {
         /// The offer string.
         offer_string: String,
+
         /// Amount the user would like to pay. If this isn't set, we'll assume the user is paying
         /// whatever the offer amount is.
         #[arg(required = false)]
         amount: Option<u64>,
+
+        /// A payer-provided note which will be seen by the recipient.
+        #[arg(required = false)]
+        payer_note: Option<String>,
     },
     /// PayInvoice pays a hex-encoded BOLT12 invoice.
     PayInvoice {
@@ -144,6 +153,7 @@ async fn main() {
         Commands::PayOffer {
             ref offer_string,
             amount,
+            payer_note,
         } => {
             let tls = read_cert_from_args(args.cert_pem);
             let grpc_host = args.grpc_host;
@@ -184,6 +194,7 @@ async fn main() {
             let mut request = Request::new(PayOfferRequest {
                 offer: offer.to_string(),
                 amount,
+                payer_note,
             });
             add_metadata(&mut request, macaroon).unwrap_or_else(|_| exit(1));
 
@@ -198,6 +209,7 @@ async fn main() {
         Commands::GetInvoice {
             ref offer_string,
             amount,
+            payer_note,
         } => {
             let tls = read_cert_from_args(args.cert_pem);
             let grpc_host = args.grpc_host;
@@ -237,6 +249,7 @@ async fn main() {
             let mut request = Request::new(GetInvoiceRequest {
                 offer: offer.to_string(),
                 amount,
+                payer_note,
             });
             add_metadata(&mut request, macaroon).unwrap_or_else(|_| exit(1));
             match client.get_invoice(request).await {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -274,6 +274,7 @@ pub struct PaymentInfo {
 pub struct PayOfferParams {
     pub offer: Offer,
     pub amount: Option<u64>,
+    pub payer_note: Option<String>,
     pub network: Network,
     pub client: Client,
     /// The destination the offer creator provided, which we will use to send the invoice request.
@@ -320,6 +321,7 @@ impl OfferHandler {
                 cfg.offer.clone(),
                 cfg.network,
                 cfg.amount,
+                cfg.payer_note,
             )
             .await?;
 

--- a/src/server.rs
+++ b/src/server.rs
@@ -107,6 +107,7 @@ impl Offers for LNDKServer {
         let cfg = PayOfferParams {
             offer,
             amount: inner_request.amount,
+            payer_note: inner_request.payer_note.clone(),
             network,
             client,
             destination,
@@ -199,6 +200,7 @@ impl Offers for LNDKServer {
         let cfg = PayOfferParams {
             offer,
             amount: inner_request.amount,
+            payer_note: inner_request.payer_note.clone(),
             network,
             client,
             destination,

--- a/src/server.rs
+++ b/src/server.rs
@@ -399,6 +399,9 @@ fn generate_bolt12_invoice_contents(invoice: &Bolt12Invoice) -> lndkrpc::Bolt12I
         signature: invoice.signature().to_string(),
         payment_paths: extract_payment_paths(invoice),
         features: convert_features(invoice.invoice_features().clone().encode()),
+        payer_note: invoice
+            .payer_note()
+            .map(|payer_note| payer_note.to_string()),
     }
 }
 

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -52,6 +52,7 @@ async fn create_offers(
         let pay_cfg = PayOfferParams {
             offer: offer,
             amount: Some(20_000),
+            payer_note: Some("".to_string()),
             network: Network::Regtest,
             client: client.clone(),
             destination: Destination::BlindedPath(blinded_path),
@@ -221,9 +222,9 @@ async fn test_lndk_send_invoice_request() {
         .create_invoice_request(
             client.clone(),
             offer.clone(),
-            vec![],
             Network::Regtest,
             Some(20_000),
+            Some("".to_string()),
         )
         .await
         .unwrap();
@@ -275,9 +276,9 @@ async fn test_lndk_send_invoice_request() {
         .create_invoice_request(
             client.clone(),
             offer.clone(),
-            vec![],
             Network::Regtest,
             Some(20_000),
+            Some("".to_string()),
         )
         .await
         .unwrap();
@@ -336,6 +337,7 @@ async fn test_lndk_pay_offer() {
     let pay_cfg = PayOfferParams {
         offer: offer.clone(),
         amount: Some(20_000),
+        payer_note: Some("".to_string()),
         network: Network::Regtest,
         client: client.clone(),
         destination: Destination::BlindedPath(blinded_path.clone()),
@@ -391,6 +393,7 @@ async fn test_lndk_pay_offer_concurrently() {
     let pay_cfg = PayOfferParams {
         offer: offer.clone(),
         amount: Some(20_000),
+        payer_note: Some("".to_string()),
         network: Network::Regtest,
         client: client.clone(),
         destination: Destination::BlindedPath(blinded_path.clone()),


### PR DESCRIPTION
Adds payer note into the invoice contents to make it available from decoding invoices.